### PR TITLE
Add placeholder webpage for OTT FAST Streaming

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OTT Fast Streaming Channel</title>
+</head>
+<body>
+    <h1>OTT Fast Streaming Channel</h1>
+    <p>This page was requested to summarize recent discussions about the OTT Fast Streaming channel offering at <a href="https://museplatforms.com">museplatforms.com</a>.</p>
+    <p><em>No prior conversation was found in the repository or session, so this page serves as a placeholder.</em></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add docs/index.html as placeholder for OTT Fast Streaming channel page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867c035e03c8331a87e02f4fb35beee